### PR TITLE
Potential fix for code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/app.js
+++ b/app.js
@@ -135,6 +135,11 @@ app.post('/api/add', async (req, res) => {
     res.status(500).json({ message: 'Missing URL' })
     return
   }
+  // SSRF mitigation: validate url
+  if (!isValidUrlForFetch(url)) {
+    res.status(400).json({ message: 'Invalid or forbidden URL.' })
+    return
+  }
 
   let encodedCollection = await sanitize(collection)
   let type = getFileType(url)


### PR DESCRIPTION
Potential fix for [https://github.com/voiceflow-community/langchain-local-knowledgebase/security/code-scanning/1](https://github.com/voiceflow-community/langchain-local-knowledgebase/security/code-scanning/1)

The best way to fix this SSRF vulnerability is to enforce strict validation of the incoming `url` parameter before making any HTTP request. Specifically, the validation should:
- Allow only URLs with expected, safe protocols (`https:` or possibly `http:`).
- Restrict the hostname to a pre-defined allow-list of permitted domains, or, if this is intended for public resources, block-list internal/reserved IP ranges and `localhost`.
- Parse and validate the user input with the `URL` constructor before making network requests.
- Optionally, check for additional requirements (e.g., `.pdf` file extensions) as needed, but extension filtering alone is not enough.

Implementation:
- Add a validation function, e.g., `isValidUrlForFetch(url)`, to enforce protocol, hostname/domain restrictions, and public resource checks.
- Call this validator before `fetchAndSaveFile` is executed (e.g. before line 178), and reject requests that do not pass validation.
- Ensure the validator cannot be bypassed via URL-encoded IPs (e.g., `http://2130706433/` instead of `127.0.0.1`) or other common SSRF tricks.
- This change only affects the code you have shown (app.js, especially the `/api/add` endpoint and fetch related logic), and a helper function can be defined nearby.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
